### PR TITLE
add remaining unhandled block types from the spec

### DIFF
--- a/reader_test.go
+++ b/reader_test.go
@@ -1,0 +1,112 @@
+package snappystream
+
+import (
+	"bytes"
+	"crypto/rand"
+	"io/ioutil"
+	"testing"
+)
+
+// mkpad returns a padding block with n padding bytes (total length, n+8 bytes).
+// practically useless but good enough for testing.
+func mkpad(b byte, n int) []byte {
+	if b == 0 {
+		b = 0xfe
+	}
+
+	length := uint32(n + 4)
+	lengthle := []byte{byte(length), byte(length >> 8), byte(length >> 16)}
+	checksum := make([]byte, 4)
+	_, err := rand.Read(checksum)
+	if err != nil {
+		panic(err)
+	}
+	padbytes := make([]byte, n)
+	_, err = rand.Read(padbytes)
+	if err != nil {
+		panic(err)
+	}
+
+	var h []byte
+	h = append(h, b)
+	h = append(h, lengthle...)
+	h = append(h, checksum...)
+	h = append(h, padbytes...)
+	return h
+}
+
+// This test checks that padding and reserved skippable blocks are ignored by
+// the reader.
+func TestReader_skippable(t *testing.T) {
+	var buf bytes.Buffer
+	// write some blocks with injected padding/skippable blocks
+	w := NewWriter(&buf)
+	write := func(p []byte) (int, error) {
+		return w.Write(p)
+	}
+	writepad := func(b byte, n int) (int, error) {
+		return buf.Write(mkpad(b, n))
+	}
+	_, err := write([]byte("hello"))
+	if err != nil {
+		t.Fatalf("write error: %v", err)
+	}
+	_, err = writepad(0xfe, 100) // normal padding
+	if err != nil {
+		t.Fatalf("write error: %v", err)
+	}
+	_, err = write([]byte(" "))
+	if err != nil {
+		t.Fatalf("write error: %v", err)
+	}
+	_, err = writepad(0xa0, 100) // reserved skippable block
+	if err != nil {
+		t.Fatalf("write error: %v", err)
+	}
+	_, err = writepad(0xfe, MaxBlockSize) // normal padding
+	if err != nil {
+		t.Fatalf("write error: %v", err)
+	}
+	_, err = write([]byte("padding"))
+	if err != nil {
+		t.Fatalf("write error: %v", err)
+	}
+
+	p, err := ioutil.ReadAll(NewReader(&buf, true))
+	if err != nil {
+		t.Fatalf("read error: %v", err)
+	}
+	if string(p) != "hello padding" {
+		t.Fatalf("read: unexpected content %q", string(p))
+	}
+}
+
+// This test checks that reserved unskippable blocks are cause decoder errors.
+func TestReader_unskippable(t *testing.T) {
+	var buf bytes.Buffer
+	// write some blocks with injected padding/skippable blocks
+	w := NewWriter(&buf)
+	write := func(p []byte) (int, error) {
+		return w.Write(p)
+	}
+	writepad := func(b byte, n int) (int, error) {
+		return buf.Write(mkpad(b, n))
+	}
+	_, err := write([]byte("unskippable"))
+	if err != nil {
+		t.Fatalf("write error: %v", err)
+	}
+	_, err = writepad(0x50, 100) // unskippable reserved block
+	if err != nil {
+		t.Fatalf("write error: %v", err)
+	}
+	_, err = write([]byte(" blocks"))
+	if err != nil {
+		t.Fatalf("write error: %v", err)
+	}
+
+	_, err = ioutil.ReadAll(NewReader(&buf, true))
+	if err == nil {
+		t.Fatalf("read success")
+	}
+}

--- a/snappystream.go
+++ b/snappystream.go
@@ -23,6 +23,23 @@ const MaxBlockSize = 65536
 const VerifyChecksum = true
 const SkipVerifyChecksum = false
 
+// Block types defined by the snappy framed format specification.
+const (
+	blockCompressed       = 0x00
+	blockUncompressed     = 0x01
+	blockPadding          = 0xfe
+	blockStreamIdentifier = 0xff
+)
+
+// streamID is the stream identifier block that begins a valid snappy framed
+// stream.
+var streamID = []byte{0xff, 0x06, 0x00, 0x00, 0x73, 0x4e, 0x61, 0x50, 0x70, 0x59}
+
+// maskChecksum implements the checksum masking algorithm described by the spec.
+func maskChecksum(c uint32) uint32 {
+	return ((c >> 15) | (c << 17)) + 0xa282ead8
+}
+
 var crcTable *crc32.Table
 
 func init() {

--- a/writer.go
+++ b/writer.go
@@ -9,9 +9,6 @@ import (
 	"code.google.com/p/snappy-go/snappy"
 )
 
-// includes block header
-var streamID = []byte{0xff, 0x06, 0x00, 0x00, 0x73, 0x4e, 0x61, 0x50, 0x70, 0x59}
-
 type writer struct {
 	writer io.Writer
 
@@ -97,10 +94,11 @@ func (w *writer) write(p []byte) (int, error) {
 		w.sentStreamID = true
 	}
 
+	// set the block type
 	if compressed {
-		w.hdr[0] = 0x00 // compressed frame ID
+		w.hdr[0] = blockCompressed
 	} else {
-		w.hdr[0] = 0x01 // uncomprsessed frame ID
+		w.hdr[0] = blockUncompressed
 	}
 
 	// 3 byte little endian length of encoded content
@@ -127,8 +125,4 @@ func (w *writer) write(p []byte) (int, error) {
 	}
 
 	return n, nil
-}
-
-func maskChecksum(c uint32) uint32 {
-	return ((c >> 15) | (c << 17)) + 0xa282ead8
 }


### PR DESCRIPTION
adds support for decoding padding blocks and skippable (reserved) blocks
