### PR TITLE
avoid unnecessary allocations in snappy.Encode

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -148,6 +148,7 @@ func (w *writer) write(p []byte) (int, error) {
 		return 0, errors.New(fmt.Sprintf("block too large %d > %d", len(p), MaxBlockSize))
 	}
 
+	w.dst = w.dst[:cap(w.dst)] // Encode does dumb resize w/o context. reslice avoids alloc.
 	w.dst, err = snappy.Encode(w.dst, p)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
I just looked at the snappy-go code a bit and realized that the way Encode is used can trigger a lot of unnecessary allocations.

https://code.google.com/p/snappy-go/source/browse/snappy/encode.go#82

It was fairly trivial to optimize this.
