### PR TITLE
Reader returns an error if the first block is not streamID

### DIFF
--- a/readwrite_test.go
+++ b/readwrite_test.go
@@ -148,7 +148,7 @@ func TestWriterChunk(t *testing.T) {
 	out := make([]byte, len(in))
 	n, err = io.ReadFull(r, out)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err)
 	}
 	if n != len(in) {
 		t.Fatalf("read wrong amount %d != %d", n, len(in))
@@ -216,7 +216,7 @@ func benchmarkWriterBytes(b *testing.B, p []byte) {
 		w := NewWriter(ioutil.Discard) // create every time for stream identifier
 		n, err := io.Copy(w, dummyBytesReader(p))
 		if err != nil {
-			b.Fatalf(err.Error())
+			b.Fatal(err)
 		}
 		if n != int64(len(p)) {
 			b.Fatalf("wrote wrong amount %d != %d", n, len(p))
@@ -300,7 +300,7 @@ func benchmarkReaderDiscard(b *testing.B, p []byte) {
 	w := NewWriter(&buf)
 	_, err := io.Copy(w, dummyBytesReader(p))
 	if err != nil {
-		b.Fatal("pre-test compression: %v", err)
+		b.Fatalf("pre-test compression: %v", err)
 	}
 	encp := buf.Bytes()
 
@@ -324,11 +324,11 @@ func benchmarkReaderDiscard_buffered(b *testing.B, p []byte) {
 	w := NewBufferedWriter(&buf)
 	_, err := io.Copy(w, dummyBytesReader(p))
 	if err != nil {
-		b.Fatal("pre-test compression: %v", err)
+		b.Fatalf("pre-test compression: %v", err)
 	}
 	err = w.Close()
 	if err != nil {
-		b.Fatal("pre-test compression: %v", err)
+		b.Fatalf("pre-test compression: %v", err)
 	}
 	encp := buf.Bytes()
 

--- a/writer.go
+++ b/writer.go
@@ -92,6 +92,7 @@ func (w *BufferedWriter) Close() error {
 
 type writer struct {
 	writer io.Writer
+	err    error
 
 	hdr []byte
 	dst []byte
@@ -120,6 +121,10 @@ func NewWriter(w io.Writer) io.Writer {
 }
 
 func (w *writer) Write(p []byte) (int, error) {
+	if w.err != nil {
+		return 0, w.err
+	}
+
 	total := 0
 	sz := MaxBlockSize
 	var n int
@@ -128,10 +133,9 @@ func (w *writer) Write(p []byte) (int, error) {
 			sz = len(p) - i
 		}
 
-		var err error
-		n, err = w.write(p[i : i+sz])
-		if err != nil {
-			return 0, err
+		n, w.err = w.write(p[i : i+sz])
+		if w.err != nil {
+			return 0, w.err
 		}
 		total += n
 	}

--- a/writer_test.go
+++ b/writer_test.go
@@ -108,7 +108,7 @@ func TestBufferedWriterFlush(t *testing.T) {
 		}
 		err = bw.Flush()
 		if err != nil {
-			t.Fatal("flush: %v", err)
+			t.Fatalf("flush: %v", err)
 		}
 	}
 	err := bw.Close()


### PR DESCRIPTION
Also fixed various fmt bugs in the tests. (edit: i really need to inject go vet into my workflow, i added a lot of those things :frowning:)

Fixes #8.
