### PR TITLE
reader: rewrite nextFrame to fix various bugs.

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -2,13 +2,18 @@ package snappystream
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"hash/crc32"
 	"io"
+	"io/ioutil"
 
 	"code.google.com/p/snappy-go/snappy"
 )
+
+// errMssingStreamID is returned from a reader when the source stream does not
+// begin with a stream identifier block (4.1 Stream identifier).  Its occurance
+// signifies that the source byte stream is not snappy framed.
+var errMissingStreamID = fmt.Errorf("missing stream identifier")
 
 type reader struct {
 	reader io.Reader
@@ -40,8 +45,6 @@ type reader struct {
 // For each Read, the returned length will be up to the lesser of len(b) or 65536
 // decompressed bytes, regardless of the length of *compressed* bytes read
 // from the wrapped io.Reader.
-//
-// BUG: padding is not allowed to be larger than MaxBlockSize.
 func NewReader(r io.Reader, verifyChecksum bool) io.Reader {
 	return &reader{
 		reader: r,
@@ -81,80 +84,120 @@ func (r *reader) Read(b []byte) (int, error) {
 
 func (r *reader) nextFrame() error {
 	for {
+		// read the 4-byte snappy frame header
 		_, err := io.ReadFull(r.reader, r.hdr)
 		if err != nil {
 			return err
 		}
 
-		// ensure the first block of the stream is a stream identifier.  check
-		// the header before reading the block to avoid unnecessary work.
-		if !r.seenStreamID {
-			if r.hdr[0] != blockStreamIdentifier {
-				return fmt.Errorf("missing stream identifier %#x", r.hdr[0])
-			}
-			if !bytes.Equal(r.hdr, streamID[:4]) {
-				return fmt.Errorf("invalid stream identifier header %v", r.hdr)
+		// a stream identifier may appear anywhere and contains no information.
+		// it must appear at the beginning of the stream.  when found, validate
+		// it and continue to the next block.
+		if r.hdr[0] == blockStreamIdentifier {
+			err := r.readStreamID()
+			if err != nil {
+				return err
 			}
 			r.seenStreamID = true
-		}
-
-		buf, err := r.readBlock()
-		if err != nil {
-			return err
-		}
-
-		switch typ := r.hdr[0]; typ {
-		case blockCompressed, blockUncompressed:
-			// compressed or uncompressed bytes
-
-			// first 4 bytes are the little endian crc32 checksum
-			checksum := unmaskChecksum(uint32(buf[0]) | uint32(buf[1])<<8 | uint32(buf[2])<<16 | uint32(buf[3])<<24)
-			b := buf[4:]
-
-			if typ == blockCompressed {
-				r.dst, err = snappy.Decode(r.dst, b)
-				if err != nil {
-					return err
-				}
-				b = r.dst
-			}
-
-			if r.verifyChecksum {
-				actualChecksum := crc32.Checksum(b, crcTable)
-				if checksum != actualChecksum {
-					return errors.New(fmt.Sprintf("invalid checksum %x != %x", checksum, actualChecksum))
-				}
-			}
-
-			_, err = r.buf.Write(b)
-			return err
-		case blockPadding:
-			// do not verify block checksum or inspect data in any way.
 			continue
-		case blockStreamIdentifier:
-			if !bytes.Equal(buf, streamID[4:]) {
-				return errors.New("invalid stream ID")
+		}
+		if !r.seenStreamID {
+			return errMissingStreamID
+		}
+
+		switch typ := r.hdr[0]; {
+		case typ == blockCompressed || typ == blockUncompressed:
+			return r.decodeBlock()
+		case typ == blockPadding || (0x80 <= typ && typ <= 0xfd):
+			// skip blocks whose data must not be inspected (4.4 Padding, and 4.6
+			// Reserved skippable chunks).
+			err := r.discardBlock()
+			if err != nil {
+				return err
 			}
 			continue
 		default:
-			if typ >= 0x80 && typ <= 0xfd {
-				// backwards compatible block type defined to be skippable
-				continue
+			// typ must be unskippable range 0x02-0x7f.  Read the block in full
+			// and return an error (4.5 Reserved unskippable chunks).
+			err = r.discardBlock()
+			if err != nil {
+				return err
 			}
-
-			return fmt.Errorf("unrecognized unskippable frame %#x", typ)
+			return fmt.Errorf("unrecognized unskippable frame %#x", r.hdr[0])
 		}
 	}
-	panic("should never happen")
+}
+
+// decodeDataBlock assumes r.hdr[0] to be either blockCompressed or
+// blockUncompressed.
+func (r *reader) decodeBlock() error {
+	// read compressed block data and determine if uncompressed data is too
+	// large.
+	buf, err := r.readBlock()
+	if err != nil {
+		return err
+	}
+	declen := len(buf[4:])
+	if r.hdr[0] == blockCompressed {
+		declen, err = snappy.DecodedLen(buf[4:])
+		if err != nil {
+			return err
+		}
+	}
+	if declen > MaxBlockSize {
+		return fmt.Errorf("decoded block data too large %d > %d", declen, MaxBlockSize)
+	}
+
+	// decode data and verify its integrity using the little-endian crc32
+	// preceding encoded data
+	crc32le, blockdata := buf[:4], buf[4:]
+	if r.hdr[0] == blockCompressed {
+		r.dst, err = snappy.Decode(r.dst, blockdata)
+		if err != nil {
+			return err
+		}
+		blockdata = r.dst
+	}
+	if r.verifyChecksum {
+		checksum := unmaskChecksum(uint32(crc32le[0]) | uint32(crc32le[1])<<8 | uint32(crc32le[2])<<16 | uint32(crc32le[3])<<24)
+		actualChecksum := crc32.Checksum(blockdata, crcTable)
+		if checksum != actualChecksum {
+			return fmt.Errorf("checksum does not match %x != %x", checksum, actualChecksum)
+		}
+	}
+	_, err = r.buf.Write(blockdata)
+	return err
+}
+
+func (r *reader) readStreamID() error {
+	// the length of the block is fixed so don't decode it from the header.
+	if !bytes.Equal(r.hdr, streamID[:4]) {
+		return fmt.Errorf("invalid stream identifier length")
+	}
+
+	// read the identifier block data "sNaPpY"
+	block := r.src[:6]
+	_, err := noeof(io.ReadFull(r.reader, block))
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(block, streamID[4:]) {
+		return fmt.Errorf("invalid stream identifier block")
+	}
+	return nil
+}
+
+func (r *reader) discardBlock() error {
+	length := uint64(decodeLength(r.hdr[1:]))
+	_, err := noeof64(io.CopyN(ioutil.Discard, r.reader, int64(length)))
+	return err
 }
 
 func (r *reader) readBlock() ([]byte, error) {
-	// 3 byte little endian length
-	length := uint32(r.hdr[1]) | uint32(r.hdr[2])<<8 | uint32(r.hdr[3])<<16
-
-	// +4 for checksum
-	if length > (MaxBlockSize + 4) {
-		return nil, errors.New(fmt.Sprintf("block too large %d > %d", length, (MaxBlockSize + 4)))
+	// check bounds on encoded length (+4 for checksum)
+	length := decodeLength(r.hdr[1:])
+	if length > (maxEncodedBlockSize + 4) {
+		return nil, fmt.Errorf("encoded block data too large %d > %d", length, (maxEncodedBlockSize + 4))
 	}
 
 	if int(length) > len(r.src) {
@@ -162,7 +205,7 @@ func (r *reader) readBlock() ([]byte, error) {
 	}
 
 	buf := r.src[:length]
-	_, err := io.ReadFull(r.reader, buf)
+	_, err := noeof(io.ReadFull(r.reader, buf))
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +213,30 @@ func (r *reader) readBlock() ([]byte, error) {
 	return buf, nil
 }
 
+// decodeLength decodes a 24-bit (3-byte) little-endian length from b.
+func decodeLength(b []byte) uint32 {
+	return uint32(b[0]) | uint32(b[1])<<8 | uint32(b[2])<<16
+}
+
 func unmaskChecksum(c uint32) uint32 {
 	x := c - 0xa282ead8
 	return ((x >> 17) | (x << 15))
+}
+
+// noeof is used after reads in situations where EOF signifies invalid
+// formatting or corruption.
+func noeof(n int, err error) (int, error) {
+	if err == io.EOF {
+		return n, io.ErrUnexpectedEOF
+	}
+	return n, err
+}
+
+// noeof64 is used after long reads (e.g. io.Copy) in situations where io.EOF
+// signifies invalid formatting or corruption.
+func noeof64(n int64, err error) (int64, error) {
+	if err == io.EOF {
+		return n, io.ErrUnexpectedEOF
+	}
+	return n, err
 }

--- a/reader_test.go
+++ b/reader_test.go
@@ -3,37 +3,14 @@ package snappystream
 import (
 	"bytes"
 	"crypto/rand"
+	"fmt"
+	"io"
 	"io/ioutil"
+	"strings"
 	"testing"
+
+	"code.google.com/p/snappy-go/snappy"
 )
-
-// mkpad returns a padding block with n padding bytes (total length, n+8 bytes).
-// practically useless but good enough for testing.
-func mkpad(b byte, n int) []byte {
-	if b == 0 {
-		b = 0xfe
-	}
-
-	length := uint32(n + 4)
-	lengthle := []byte{byte(length), byte(length >> 8), byte(length >> 16)}
-	checksum := make([]byte, 4)
-	_, err := rand.Read(checksum)
-	if err != nil {
-		panic(err)
-	}
-	padbytes := make([]byte, n)
-	_, err = rand.Read(padbytes)
-	if err != nil {
-		panic(err)
-	}
-
-	var h []byte
-	h = append(h, b)
-	h = append(h, lengthle...)
-	h = append(h, checksum...)
-	h = append(h, padbytes...)
-	return h
-}
 
 // This test checks that padding and reserved skippable blocks are ignored by
 // the reader.
@@ -45,7 +22,7 @@ func TestReader_skippable(t *testing.T) {
 		return w.Write(p)
 	}
 	writepad := func(b byte, n int) (int, error) {
-		return buf.Write(mkpad(b, n))
+		return buf.Write(opaqueChunk(b, n))
 	}
 	_, err := write([]byte("hello"))
 	if err != nil {
@@ -90,7 +67,7 @@ func TestReader_unskippable(t *testing.T) {
 		return w.Write(p)
 	}
 	writepad := func(b byte, n int) (int, error) {
-		return buf.Write(mkpad(b, n))
+		return buf.Write(opaqueChunk(b, n))
 	}
 	_, err := write([]byte("unskippable"))
 	if err != nil {
@@ -132,7 +109,7 @@ func TestReaderStreamID(t *testing.T) {
 		t.Fatal("missing stream id")
 	}
 
-	// steramNoID is valid except for a missing the streamID block
+	// streamNoID is valid except for a missing the streamID block
 	streamNoID := bytes.TrimPrefix(stream, streamID)
 	r = NewReader(bytes.NewReader(streamNoID), true)
 	n, err := r.Read(make([]byte, 1))
@@ -149,4 +126,395 @@ func TestReaderStreamID(t *testing.T) {
 	if n != 0 {
 		t.Fatalf("read: read non-zero number of bytes %d after missing stream id error", n)
 	}
+}
+
+// This test validates the reader successfully decods a padding of maximal
+// size, 2^24 - 1.
+func TestReader_maxPad(t *testing.T) {
+	buf := bytes.NewReader(bytes.Join([][]byte{
+		streamID,
+		compressedChunk(t, []byte("a maximal padding chunk")),
+		opaqueChunk(0xfe, (1<<24)-1), // normal padding
+		compressedChunk(t, []byte(" is decoded successfully")),
+	}, nil))
+	r := NewReader(buf, true)
+	p, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read error: %v", err)
+	}
+	if string(p) != "a maximal padding chunk is decoded successfully" {
+		t.Fatalf("read: unexpected content %q", string(p))
+	}
+}
+
+// This test validates the reader successfully decodes a skippable chunk of
+// maximal size, 2^24 - 1.
+func TestReader_maxSkippable(t *testing.T) {
+	buf := bytes.NewReader(bytes.Join([][]byte{
+		streamID,
+		compressedChunk(t, []byte("a maximal skippable chunk")),
+		opaqueChunk(0xce, (1<<24)-1), // reserved skippable chunk
+		compressedChunk(t, []byte(" is decoded successfully")),
+	}, nil))
+	r := NewReader(buf, true)
+	p, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read error: %v", err)
+	}
+	if string(p) != "a maximal skippable chunk is decoded successfully" {
+		t.Fatalf("read: unexpected content %q", string(p))
+	}
+}
+
+// TestReader_maxBlock validates bounds checking on encoded and decoded data
+// (4.2 Compressed Data).
+func TestReader_maxBlock(t *testing.T) {
+	// decompressing a block with compressed length greater than MaxBlockSize
+	// should succeed.
+	buf := bytes.NewReader(bytes.Join([][]byte{
+		streamID,
+		compressedChunkGreaterN(t, MaxBlockSize),
+	}, nil))
+	r := NewReader(buf, true)
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(b) != MaxBlockSize {
+		t.Fatalf("bad read (%d bytes)", len(b))
+	}
+
+	// decompressing should fail if the block with decompressed length greater
+	// than MaxBlockSize.
+	buf = bytes.NewReader(bytes.Join([][]byte{
+		streamID,
+		compressedChunk(t, make([]byte, MaxBlockSize+1)),
+	}, nil))
+	r = NewReader(buf, true)
+	b, err = ioutil.ReadAll(r)
+	if err == nil {
+		t.Fatal("unexpected success")
+	}
+	if len(b) > 0 {
+		t.Fatalf("unexpected read %q", b)
+	}
+}
+
+// This test validates the reader's behavior encountering unskippable chunks of
+// maximal size, 2^24 - 1.  The desired error to in this case is one reporting
+// an unskippable chunk, not a length error.
+func TestReader_maxUnskippable(t *testing.T) {
+	// the first block should be decoded successfully.
+	prefix := "a maximal unskippable chunk"
+	buf := bytes.NewReader(bytes.Join([][]byte{
+		streamID,
+		compressedChunk(t, []byte(prefix)),
+		opaqueChunk(0x03, (1<<24)-1), // low end of the unskippable range
+		compressedChunk(t, []byte(" failure must be reported as such")),
+	}, nil))
+	p := make([]byte, len(prefix))
+	r := NewReader(buf, true)
+	n, err := r.Read(p)
+	if err != nil {
+		t.Fatalf("read error: %v", err)
+	}
+	if n != len(p) {
+		t.Fatalf("read: short read %d", n)
+	}
+	if string(p) != prefix {
+		t.Fatalf("read: bad value %q", p)
+	}
+
+	n, err = r.Read(p)
+	if err == nil {
+		t.Fatalf("read: expected error")
+	}
+	if n > 0 {
+		t.Fatalf("read: read %d more bytes than expected", n)
+	}
+	if !strings.Contains(err.Error(), "unskippable") {
+		t.Fatalf("read error: %v", err)
+	}
+}
+
+// This test validates errors returned when data blocks exceed size limits.
+func TestReader_blockTooLarge(t *testing.T) {
+	// the compressed chunk size is within the allowed encoding size
+	// (maxEncodedBlockSize). but the uncompressed data is larger than allowed.
+	badstream := bytes.Join([][]byte{
+		streamID,
+		compressedChunk(t, make([]byte, (1<<24)-5)),
+	}, nil)
+	r := NewReader(bytes.NewBuffer(badstream), true)
+	p := make([]byte, 1)
+	n, err := r.Read(p)
+	if err == nil {
+		t.Fatalf("read: expected error")
+	}
+	if n != 0 {
+		t.Fatalf("read: read data from the stream")
+	}
+
+	// the compressed chunk size is within the allowed encoding size
+	// (maxEncodedBlockSize). but the uncompressed data is larger than allowed.
+	badstream = bytes.Join([][]byte{
+		streamID,
+		uncompressedChunk(t, make([]byte, (1<<24)-5)),
+	}, nil)
+	r = NewReader(bytes.NewBuffer(badstream), true)
+	p = make([]byte, 1)
+	n, err = r.Read(p)
+	if err == nil {
+		t.Fatalf("read: expected error")
+	}
+	if n != 0 {
+		t.Fatalf("read: read data from the stream")
+	}
+}
+
+// This test validates the reader's handling of corrupt chunks.
+func TestReader_corruption(t *testing.T) {
+	// corruptID is a corrupt stream identifier
+	corruptID := append([]byte(nil), streamID...)
+	corruptID = bytes.Replace(streamID, []byte("p"), []byte("P"), -1) // corrupt "sNaPpY" data
+	badstream := corruptID
+
+	r := NewReader(bytes.NewBuffer(badstream), true)
+	p := make([]byte, 1)
+	n, err := r.Read(p)
+	if err == nil {
+		t.Fatalf("read: expected error")
+	}
+	if err == io.EOF {
+		t.Fatalf("read: unexpected eof")
+	}
+	if n != 0 {
+		t.Fatalf("read: read data from the stream")
+	}
+
+	corruptID = append([]byte(nil), streamID...) // corrupt the length
+	corruptID[1] = 0x00
+	badstream = corruptID
+
+	r = NewReader(bytes.NewBuffer(badstream), true)
+	p = make([]byte, 1)
+	n, err = r.Read(p)
+	if err == nil {
+		t.Fatalf("read: expected error")
+	}
+	if err == io.EOF {
+		t.Fatalf("read: unexpected eof")
+	}
+	if n != 0 {
+		t.Fatalf("read: read data from the stream")
+	}
+
+	// chunk is a valid compressed block
+	chunk := compressedChunk(t, []byte("a data block"))
+
+	// corrupt is a corrupt chunk
+	corrupt := append([]byte(nil), chunk...)
+	copy(corrupt[8:], make([]byte, 10)) // corrupt snappy-encoded data
+	badstream = bytes.Join([][]byte{
+		streamID,
+		corrupt,
+	}, nil)
+
+	r = NewReader(bytes.NewBuffer(badstream), true)
+	p = make([]byte, 1)
+	n, err = r.Read(p)
+	if err == nil {
+		t.Fatalf("read: expected error")
+	}
+	if err == io.EOF {
+		t.Fatalf("read: unexpected eof")
+	}
+	if n != 0 {
+		t.Fatalf("read: read data from the stream")
+	}
+
+	corrupt = append([]byte(nil), chunk...)
+	copy(corrupt[4:8], make([]byte, 4)) // crc checksum failure
+	badstream = bytes.Join([][]byte{
+		streamID,
+		corrupt,
+	}, nil)
+
+	r = NewReader(bytes.NewBuffer(badstream), true)
+	p = make([]byte, 1)
+	n, err = r.Read(p)
+	if err == nil {
+		t.Fatalf("read: expected error")
+	}
+	if err == io.EOF {
+		t.Fatalf("read: unexpected eof")
+	}
+	if n != 0 {
+		t.Fatalf("read: read data from the stream")
+	}
+}
+
+// This test ensures that reader returns io.ErrUnexpectedEOF at the appropriate
+// times. io.EOF must be reserved for the case when all data has been
+// successfully decoded.
+func TestReader_unexpectedEOF(t *testing.T) {
+	var decodeBuffer [64 << 10]byte
+
+	for _, test := range [][]byte{
+		// truncated streamIDs
+		streamID[:4],
+		streamID[:len(streamID)-1],
+
+		// truncated data blocks
+		bytes.Join([][]byte{
+			streamID,
+			compressedChunk(t, bytes.Repeat([]byte("abc"), 100))[:2],
+		}, nil),
+		bytes.Join([][]byte{
+			streamID,
+			compressedChunk(t, bytes.Repeat([]byte("abc"), 100))[:7],
+		}, nil),
+
+		// truncated padding
+		bytes.Join([][]byte{
+			streamID,
+			opaqueChunk(0xfe, 100)[:1],
+		}, nil),
+		bytes.Join([][]byte{
+			streamID,
+			opaqueChunk(0xfe, 100)[:8],
+		}, nil),
+
+		// truncated skippable chunk
+		bytes.Join([][]byte{
+			streamID,
+			opaqueChunk(0xcf, 100)[:3],
+		}, nil),
+		bytes.Join([][]byte{
+			streamID,
+			opaqueChunk(0xcf, 100)[:7],
+		}, nil),
+
+		// truncated unskippable chunk
+		bytes.Join([][]byte{
+			streamID,
+			opaqueChunk(0x03, 100)[:3],
+		}, nil),
+		bytes.Join([][]byte{
+			streamID,
+			opaqueChunk(0x03, 100)[:5],
+		}, nil),
+	} {
+		r := NewReader(bytes.NewReader(test), true)
+		n, err := r.Read(decodeBuffer[:])
+		if err == nil {
+			t.Errorf("read bad streamID: expected error")
+		}
+		if err != io.ErrUnexpectedEOF {
+			t.Errorf("read bad streamID: %v", err)
+		}
+		if n != 0 {
+			t.Errorf("read bad streamID: expected read length %d", n)
+		}
+	}
+}
+
+var errNotEnoughEntropy = fmt.Errorf("inadequate entropy in PRNG")
+
+// compressedChunkGreaterN like compressedChunk produces a single, compressed,
+// snappy-framed block. The returned block will have decoded length at most n
+// and encoded length greater than n.
+func compressedChunkGreaterN(t *testing.T, n int) []byte {
+	decoded := make([]byte, n)
+	var numTries int
+	var encoded []byte
+	for len(encoded) <= n && numTries < 3 {
+		numTries++
+		nrd, err := io.ReadFull(rand.Reader, decoded)
+		if err != nil {
+			t.Errorf("crypto/rand: %v", err)
+			return nil
+		}
+		if nrd != n {
+			t.Errorf("crypto/rand: bad read (%d bytes)", nrd)
+			return nil
+		}
+		encoded, err = snappy.Encode(encoded[:cap(encoded)], decoded)
+		if err != nil {
+			t.Errorf("snappy: %v", err)
+			return nil
+		}
+	}
+	if len(encoded) <= n {
+		t.Error(errNotEnoughEntropy)
+		return nil
+	}
+
+	return compressedChunk(t, decoded)
+}
+
+// compressedChunk encodes b returning a single, compressed, snappy-framed
+// block. compressedChunk can encode source data larger than allowed in the
+// specification.
+func compressedChunk(t *testing.T, src []byte) []byte {
+	encoded, err := snappy.Encode(nil, src)
+	if err != nil {
+		t.Errorf("snappy: %v", err)
+		return nil
+	}
+
+	if len(encoded) > (1<<24)-5 { // account for the 4-byte checksum
+		t.Errorf("block data too large %d", len(src))
+		return nil
+	}
+
+	chunk := make([]byte, len(encoded)+8)
+	writeHeader(chunk[:8], blockCompressed, encoded, src)
+	copy(chunk[8:], encoded)
+	return chunk
+}
+
+// uncompressedChunk encodes b returning a single, uncompressed, snappy-framed
+// block. uncompressedChunk can encode chunks larger than allowed by the
+// specification.
+func uncompressedChunk(t *testing.T, src []byte) []byte {
+	if len(src) > (1<<24)-5 { // account for the 4-byte checksum
+		t.Errorf("block data too large %d", len(src))
+		return nil
+	}
+
+	chunk := make([]byte, len(src)+8)
+	writeHeader(chunk[:8], blockUncompressed, src, src)
+	copy(chunk[8:], src)
+	return chunk
+}
+
+// opaqueChunk returns an opaque b chunk (e.g. padding 0xfe) with length n
+// (total length, n+4 bytes).  practically useless but good enough for testing.
+// the first 4-bytes of data are random to ensure checksums are not being
+// verified.
+func opaqueChunk(b byte, n int) []byte {
+	if b == 0 {
+		b = 0xfe
+	}
+
+	length := uint32(n)
+	lengthle := []byte{byte(length), byte(length >> 8), byte(length >> 16)}
+	checksum := make([]byte, 4)
+	_, err := rand.Read(checksum)
+	if err != nil {
+		panic(err)
+	}
+	padbytes := make([]byte, n-4) // let this panic if n < 4
+	_, err = rand.Read(padbytes)
+	if err != nil {
+		panic(err)
+	}
+
+	var h []byte
+	h = append(h, b)
+	h = append(h, lengthle...)
+	h = append(h, checksum...)
+	h = append(h, padbytes...)
+	return h
 }

--- a/snappystream.go
+++ b/snappystream.go
@@ -5,6 +5,8 @@ package snappystream
 
 import (
 	"hash/crc32"
+
+	"code.google.com/p/snappy-go/snappy"
 )
 
 // Ext is the file extension for files whose content is a snappy framed stream.
@@ -20,6 +22,11 @@ const ContentEncoding = "x-snappy-framed"
 // MaxBlockSize is the maximum number of decoded bytes allowed to be
 // represented in a snappy framed block (sections 4.2 and 4.3).
 const MaxBlockSize = 65536
+
+// maxEncodedBlockSize is the maximum number of encoded bytes in a framed
+// block.
+var maxEncodedBlockSize = uint32(snappy.MaxEncodedLen(MaxBlockSize))
+
 const VerifyChecksum = true
 const SkipVerifyChecksum = false
 


### PR DESCRIPTION
Fixes #5 along with other bugs related to chunk size and handling of
EOF.
- compressed blocks may have length up to
  snappy.MaxEncodedLen(MaxBlockSize), the longest block which could
  successfully decode to MaxBlockSize or fewer bytes. blocks are
  checked to have decoded length at most MaxBlockSize before being
  decoded.
- successfully decodes padding and skippable chunks with size up to
  2^24-1, the maximum representable chunk size.
- fixes error reporting for reserved unskippable blocks with length
  greater than MaxBlockSize up to 2^24 -1. instead of being reported
  as too long they are reported as unskippable blocks.
- ~~simplify reader tests.~~ (edit: I ended up leaving the existing tests mostly the same)
- fix occurrences of the reader returning EOF after partial decoding.
