### PR TITLE
implement io.Copy interfaces: io.ReaderFrom and io.WriterTo

### DIFF
--- a/reader_test.go
+++ b/reader_test.go
@@ -518,3 +518,32 @@ func opaqueChunk(b byte, n int) []byte {
 	h = append(h, padbytes...)
 	return h
 }
+
+func TestReaderWriteTo(t *testing.T) {
+	var encbuf bytes.Buffer
+	var decbuf bytes.Buffer
+	msg := "hello copy interface"
+
+	w := NewWriter(&encbuf)
+	n, err := io.WriteString(w, msg)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	if n != len(msg) {
+		t.Fatalf("encode: %v", err)
+	}
+
+	r := NewReader(&encbuf, true)
+	n64, err := r.(*reader).WriteTo(&decbuf)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if n64 != int64(len(msg)) {
+		t.Fatalf("decode: decoded %d bytes %q", n64, decbuf.Bytes())
+	}
+
+	decmsg := decbuf.String()
+	if decmsg != msg {
+		t.Fatalf("decode: %q", decmsg)
+	}
+}

--- a/writer.go
+++ b/writer.go
@@ -43,6 +43,20 @@ func NewBufferedWriter(w io.Writer) *BufferedWriter {
 	}
 }
 
+// ReadFrom implements the io.ReaderFrom interface used by io.Copy. It encodes
+// data read from r as a snappy framed stream that is written to the underlying
+// writer.  ReadFrom returns the number number of bytes read, along with any
+// error encountered (other than io.EOF).
+func (w *BufferedWriter) ReadFrom(r io.Reader) (int64, error) {
+	if w.err != nil {
+		return 0, w.err
+	}
+
+	var n int64
+	n, w.err = w.bw.ReadFrom(r)
+	return n, w.err
+}
+
 // Write buffers p internally, encoding and writing a block to the underlying
 // buffer if the buffer grows beyond MaxBlockSize bytes.  The returned int
 // will be 0 if there was an error and len(p) otherwise.


### PR DESCRIPTION
This pull request optimizes use of ~~io.Reader and io.BufferedWriter~~ (edit: the **reader** and **BufferedWriter** types in this package) in io.Copy.

In my opinion it didn't make sense to implement the io.ReaderFrom interface in the non-buffered writer. Since it does not buffer its input the way to actually implement is basically to allocate a BufferedWriter and call its ReadFrom method on each invocation. You would probably see a slowdown (due to larger allocations). The only benefit would be in the compression ratio of the output.

The benchmarks were already using io.Copy, so their performance was improved with these changes (except for benchmarks of the non-buffered writer).

Due to the drastic difference in some benchmarks I was wondering if it would be better to fork the benchmarks, creating one version that exploits the interfaces and one that doesn't. I do think it's important to benchmark with the interface, bypassing buffering/memcpy allows the internals to be more precisely benchmarked and optimized. 

```
benchmark                            old ns/op     new ns/op     delta
BenchmarkWriterManpage               42666         41468         -2.81%
BenchmarkBufferedWriterManpage       60727         48590         -19.99%
BenchmarkWriterJSON                  435931        436059        +0.03%
BenchmarkBufferedWriterJSON          459506        436421        -5.02%
BenchmarkWriterRandom                218363022     218837476     +0.22%
BenchmarkBufferedWriterRandom        213386417     212948048     -0.21%
BenchmarkWriterConstant              15240343      15226202      -0.09%
BenchmarkBufferedWriterConstant      15054163      14622514      -2.87%
BenchmarkReaderManpage               22753         19413         -14.68%
BenchmarkReaderManpage_buffered      22720         19383         -14.69%
BenchmarkReaderJSON                  351204        316192        -9.97%
BenchmarkReaderJSON_buffered         360981        320058        -11.34%
BenchmarkReaderRandom                2795274       1866832       -33.21%
BenchmarkReaderRandom_buffered       2782590       1864450       -33.00%
BenchmarkReaderConstant              16623756      15915651      -4.26%
BenchmarkReaderConstant_buffered     16565261      15890398      -4.07%

benchmark                            old MB/s     new MB/s     speedup
BenchmarkWriterManpage               99.07        101.93       1.03x
BenchmarkBufferedWriterManpage       69.61        86.99        1.25x
BenchmarkWriterJSON                  360.97       360.87       1.00x
BenchmarkBufferedWriterJSON          342.45       360.57       1.05x
BenchmarkWriterRandom                48.02        47.92        1.00x
BenchmarkBufferedWriterRandom        49.14        49.24        1.00x
BenchmarkWriterConstant              688.03       688.67       1.00x
BenchmarkBufferedWriterConstant      696.54       717.10       1.03x
BenchmarkReaderManpage               112.07       131.35       1.17x
BenchmarkReaderManpage_buffered      112.23       131.55       1.17x
BenchmarkReaderJSON                  69.55        77.26        1.11x
BenchmarkReaderJSON_buffered         62.55        70.54        1.13x
BenchmarkReaderRandom                3752.16      5618.25      1.50x
BenchmarkReaderRandom_buffered       3768.81      5624.74      1.49x
BenchmarkReaderConstant              29.82        31.14        1.04x
BenchmarkReaderConstant_buffered     29.80        31.06        1.04x
```
