### PR TITLE
fix build error: panic instead of (unreachable) return

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -148,7 +148,7 @@ func (r *reader) nextFrame(w io.Writer) (int, error) {
 			return 0, fmt.Errorf("unrecognized unskippable frame %#x", r.hdr[0])
 		}
 	}
-	return nil
+	panic("unreachable")
 }
 
 // decodeDataBlock assumes r.hdr[0] to be either blockCompressed or


### PR DESCRIPTION
Oh no! I broke it :frowning: Sorry!

I didn't see that go1.0 compatibility commit. A little silly that in 1.0 the missing return was an error and now govet complains that the return is unreachable. \sigh Self-improvement is hard.
