### PR TITLE
benchmark variations which do not use io.Copy interfaces

### DIFF
--- a/readwrite_test.go
+++ b/readwrite_test.go
@@ -162,187 +162,264 @@ func TestWriterChunk(t *testing.T) {
 func BenchmarkWriterManpage(b *testing.B) {
 	benchmarkWriterBytes(b, testDataMan)
 }
-
 func BenchmarkBufferedWriterManpage(b *testing.B) {
 	benchmarkBufferedWriterBytes(b, testDataMan)
+}
+func BenchmarkBufferedWriterManpageNoCopy(b *testing.B) {
+	benchmarkBufferedWriterBytesNoCopy(b, testDataMan)
 }
 
 func BenchmarkWriterJSON(b *testing.B) {
 	benchmarkWriterBytes(b, testDataJSON)
 }
-
 func BenchmarkBufferedWriterJSON(b *testing.B) {
 	benchmarkBufferedWriterBytes(b, testDataJSON)
 }
+func BenchmarkBufferedWriterJSONNoCopy(b *testing.B) {
+	benchmarkBufferedWriterBytesNoCopy(b, testDataJSON)
+}
 
-// BenchmarkWriterRandom tests basically uncompressable data.
+// BenchmarkWriterRandom tests performance encoding effectively uncompressable
+// data.
 func BenchmarkWriterRandom(b *testing.B) {
-	size := TestFileSize
-	randp := make([]byte, size)
-	_, err := rand.Read(randp)
-	if err != nil {
-		b.Fatal(err)
-	}
-	benchmarkWriterBytes(b, randp)
+	benchmarkWriterBytes(b, randBytes(b, TestFileSize))
 }
-
 func BenchmarkBufferedWriterRandom(b *testing.B) {
-	size := TestFileSize
-	randp := make([]byte, size)
-	_, err := rand.Read(randp)
-	if err != nil {
-		b.Fatal(err)
-	}
-	benchmarkBufferedWriterBytes(b, randp)
+	benchmarkBufferedWriterBytes(b, randBytes(b, TestFileSize))
+}
+func BenchmarkBufferedWriterRandomNoCopy(b *testing.B) {
+	benchmarkBufferedWriterBytesNoCopy(b, randBytes(b, TestFileSize))
 }
 
-// BenchmarkWriterConstant tests maximally compressible data
+// BenchmarkWriterConstant tests performance encoding maximally compressible
+// data.
 func BenchmarkWriterConstant(b *testing.B) {
-	size := TestFileSize
-	zerop := make([]byte, size)
-	benchmarkWriterBytes(b, zerop)
+	benchmarkWriterBytes(b, make([]byte, TestFileSize))
 }
-
 func BenchmarkBufferedWriterConstant(b *testing.B) {
-	size := TestFileSize
-	zerop := make([]byte, size)
-	benchmarkBufferedWriterBytes(b, zerop)
+	benchmarkBufferedWriterBytes(b, make([]byte, TestFileSize))
+}
+func BenchmarkBufferedWriterConstantNoCopy(b *testing.B) {
+	benchmarkBufferedWriterBytesNoCopy(b, make([]byte, TestFileSize))
 }
 
 func benchmarkWriterBytes(b *testing.B, p []byte) {
-	b.SetBytes(int64(len(p)))
+	enc := func() io.WriteCloser {
+		// wrap the normal writer so that it has a noop Close method.  writer
+		// does not implement ReaderFrom so this does not impact performance.
+		return &nopWriteCloser{NewWriter(ioutil.Discard)}
+	}
+	benchmarkEncode(b, enc, p)
+}
+func benchmarkBufferedWriterBytes(b *testing.B, p []byte) {
+	enc := func() io.WriteCloser {
+		// the writer's ReaderFrom implemention will be used in the benchmark.
+		return NewBufferedWriter(ioutil.Discard)
+	}
+	benchmarkEncode(b, enc, p)
+}
+func benchmarkBufferedWriterBytesNoCopy(b *testing.B, p []byte) {
+	enc := func() io.WriteCloser {
+		// the writer is wrapped as to hide it's ReaderFrom implemention.
+		return &writeCloserNoCopy{NewBufferedWriter(ioutil.Discard)}
+	}
+	benchmarkEncode(b, enc, p)
+}
+
+// benchmarkEncode benchmarks the speed at which bytes can be copied from
+// bs into writers created by enc.
+func benchmarkEncode(b *testing.B, enc func() io.WriteCloser, bs []byte) {
+	size := int64(len(bs))
+	b.SetBytes(size)
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		w := NewWriter(ioutil.Discard) // create every time for stream identifier
-		n, err := io.Copy(w, dummyBytesReader(p))
+		w := enc()
+		n, err := io.Copy(w, dummyBytesReader(bs))
 		if err != nil {
 			b.Fatal(err)
 		}
-		if n != int64(len(p)) {
-			b.Fatalf("wrote wrong amount %d != %d", n, len(p))
-		}
-	}
-	b.StopTimer()
-}
-
-func benchmarkBufferedWriterBytes(b *testing.B, p []byte) {
-	b.SetBytes(int64(len(p)))
-	b.StartTimer()
-	for i := 0; i < b.N; i++ {
-		w := NewBufferedWriter(ioutil.Discard)
-		n, err := io.Copy(w, dummyBytesReader(p))
-		if err != nil {
-			b.Fatalf(err.Error())
-		}
-		if n != int64(len(p)) {
-			b.Fatalf("wrote wrong amount %d != %d", n, len(p))
+		if n != size {
+			b.Fatalf("wrote wrong amount %d != %d", n, size)
 		}
 		err = w.Close()
 		if err != nil {
-			b.Fatal(err)
+			b.Fatalf("close: %v", err)
 		}
 	}
 	b.StopTimer()
 }
 
 func BenchmarkReaderManpage(b *testing.B) {
-	benchmarkReaderDiscard(b, testDataMan)
+	encodeAndBenchmarkReader(b, testDataMan)
 }
-
 func BenchmarkReaderManpage_buffered(b *testing.B) {
-	benchmarkReaderDiscard_buffered(b, testDataMan)
+	encodeAndBenchmarkReader_buffered(b, testDataMan)
+}
+func BenchmarkReaderManpageNoCopy(b *testing.B) {
+	encodeAndBenchmarkReader_buffered(b, testDataMan)
 }
 
 func BenchmarkReaderJSON(b *testing.B) {
-	benchmarkReaderDiscard(b, testDataJSON)
+	encodeAndBenchmarkReader(b, testDataJSON)
 }
-
 func BenchmarkReaderJSON_buffered(b *testing.B) {
-	benchmarkReaderDiscard_buffered(b, testDataJSON)
+	encodeAndBenchmarkReader_buffered(b, testDataJSON)
+}
+func BenchmarkReaderJSONNoCopy(b *testing.B) {
+	encodeAndBenchmarkReader_buffered(b, testDataJSON)
 }
 
-// BenchmarkReaderRandom tests basically uncompressable data.
+// BenchmarkReaderRandom tests decoding of effectively uncompressable data.
 func BenchmarkReaderRandom(b *testing.B) {
-	size := TestFileSize
-	randp := make([]byte, size)
-	_, err := rand.Read(randp)
-	if err != nil {
-		b.Fatal(err)
-	}
-	benchmarkReaderDiscard(b, randp)
+	encodeAndBenchmarkReader(b, randBytes(b, TestFileSize))
 }
-
 func BenchmarkReaderRandom_buffered(b *testing.B) {
-	size := TestFileSize
-	randp := make([]byte, size)
-	_, err := rand.Read(randp)
-	if err != nil {
-		b.Fatal(err)
-	}
-	benchmarkReaderDiscard_buffered(b, randp)
+	encodeAndBenchmarkReader_buffered(b, randBytes(b, TestFileSize))
+}
+func BenchmarkReaderRandomNoCopy(b *testing.B) {
+	encodeAndBenchmarkReaderNoCopy(b, randBytes(b, TestFileSize))
 }
 
-// BenchmarkReaderConstant tests maximally compressible data
+// BenchmarkReaderConstant tests decoding of maximally compressible data.
 func BenchmarkReaderConstant(b *testing.B) {
-	size := TestFileSize
-	zerop := make([]byte, size)
-	benchmarkReaderDiscard(b, zerop)
+	encodeAndBenchmarkReader(b, make([]byte, TestFileSize))
 }
-
 func BenchmarkReaderConstant_buffered(b *testing.B) {
-	size := TestFileSize
-	zerop := make([]byte, size)
-	benchmarkReaderDiscard_buffered(b, zerop)
+	encodeAndBenchmarkReader_buffered(b, make([]byte, TestFileSize))
+}
+func BenchmarkReaderConstantNoCopy(b *testing.B) {
+	encodeAndBenchmarkReaderNoCopy(b, make([]byte, TestFileSize))
 }
 
-func benchmarkReaderDiscard(b *testing.B, p []byte) {
-	var buf bytes.Buffer
-	w := NewWriter(&buf)
-	_, err := io.Copy(w, dummyBytesReader(p))
+// encodeAndBenchmarkReader is a helper that benchmarks the package
+// reader's performance given p encoded as a snappy framed stream.
+//
+// encodeAndBenchmarkReader benchmarks decoding of streams containing
+// (multiple) short frames.
+func encodeAndBenchmarkReader(b *testing.B, p []byte) {
+	enc, err := encodeStreamBytes(p, false)
 	if err != nil {
-		b.Fatalf("pre-test compression: %v", err)
+		b.Fatalf("pre-benchmark compression: %v", err)
 	}
-	encp := buf.Bytes()
+	dec := func(r io.Reader) io.Reader {
+		return NewReader(r, VerifyChecksum)
+	}
+	benchmarkDecode(b, dec, int64(len(p)), enc)
+}
 
-	b.SetBytes(int64(len(encp)))
+// encodeAndBenchmarkReader_buffered is a helper that benchmarks the
+// package reader's performance given p encoded as a snappy framed stream.
+//
+// encodeAndBenchmarkReader_buffered benchmarks decoding of streams that
+// contain at most one short frame (at the end).
+func encodeAndBenchmarkReader_buffered(b *testing.B, p []byte) {
+	enc, err := encodeStreamBytes(p, true)
+	if err != nil {
+		b.Fatalf("pre-benchmark compression: %v", err)
+	}
+	dec := func(r io.Reader) io.Reader {
+		return NewReader(r, VerifyChecksum)
+	}
+	benchmarkDecode(b, dec, int64(len(p)), enc)
+}
+
+// encodeAndBenchmarkReader_nocopy is a helper that benchmarks the
+// package reader's performance given p encoded as a snappy framed stream.
+// encodeAndBenchmarReaderNoCopy avoids use of the reader's io.WriterTo
+// interface.
+//
+// encodeAndBenchmarkReader_nocopy benchmarks decoding of streams that
+// contain at most one short frame (at the end).
+func encodeAndBenchmarkReaderNoCopy(b *testing.B, p []byte) {
+	enc, err := encodeStreamBytes(p, true)
+	if err != nil {
+		b.Fatalf("pre-benchmark compression: %v", err)
+	}
+	dec := func(r io.Reader) io.Reader {
+		return ioutil.NopCloser(NewReader(r, VerifyChecksum))
+	}
+	benchmarkDecode(b, dec, int64(len(p)), enc)
+}
+
+// benchmarkDecode runs a benchmark that repeatedly decoded snappy
+// framed bytes enc.  The length of the decoded result in each iteration must
+// equal size.
+func benchmarkDecode(b *testing.B, dec func(io.Reader) io.Reader, size int64, enc []byte) {
+	b.SetBytes(int64(len(enc))) // BUG this is probably wrong
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		r := NewReader(dummyBytesReader(encp), true)
+		r := dec(bytes.NewReader(enc))
 		n, err := io.Copy(ioutil.Discard, r)
 		if err != nil {
 			b.Fatalf(err.Error())
 		}
-		if n != int64(len(p)) {
-			b.Fatalf("read wrong amount %d != %d", n, len(p))
+		if n != size {
+			b.Fatalf("read wrong amount %d != %d", n, size)
 		}
 	}
 	b.StopTimer()
 }
 
-func benchmarkReaderDiscard_buffered(b *testing.B, p []byte) {
+// encodeStreamBytes is like encodeStream but operates on a byte slice.
+// encodeStreamBytes ensures that long streams are not maximally compressed if
+// buffer is false.
+func encodeStreamBytes(b []byte, buffer bool) ([]byte, error) {
+	return encodeStream(dummyBytesReader(b), buffer)
+}
+
+// encodeStream encodes data read from r as a snappy framed stream and returns
+// the result as a byte slice.  if buffer is true the bytes from r are buffered
+// to improve the resulting slice's compression ratio.
+func encodeStream(r io.Reader, buffer bool) ([]byte, error) {
 	var buf bytes.Buffer
+	if !buffer {
+		w := NewWriter(&buf)
+		_, err := io.Copy(w, r)
+		if err != nil {
+			return nil, err
+		}
+		return buf.Bytes(), nil
+	}
+
 	w := NewBufferedWriter(&buf)
-	_, err := io.Copy(w, dummyBytesReader(p))
+	_, err := io.Copy(w, r)
 	if err != nil {
-		b.Fatalf("pre-test compression: %v", err)
+		return nil, err
 	}
 	err = w.Close()
 	if err != nil {
-		b.Fatalf("pre-test compression: %v", err)
+		return nil, err
 	}
-	encp := buf.Bytes()
+	return buf.Bytes(), nil
+}
 
-	b.SetBytes(int64(len(encp)))
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		r := NewReader(dummyBytesReader(encp), true)
-		n, err := io.Copy(ioutil.Discard, r)
-		if err != nil {
-			b.Fatalf(err.Error())
-		}
-		if n != int64(len(p)) {
-			b.Fatalf("read wrong amount %d != %d", n, len(p))
-		}
+// randBytes reads size bytes from the computer's cryptographic random source.
+// the resulting bytes have approximately maximal entropy and are effectively
+// uncompressible with any algorithm.
+func randBytes(b *testing.B, size int) []byte {
+	randp := make([]byte, size)
+	_, err := io.ReadFull(rand.Reader, randp)
+	if err != nil {
+		b.Fatal(err)
 	}
-	b.StopTimer()
+	return randp
+}
+
+// writeCloserNoCopy is an io.WriteCloser that simply wraps another
+// io.WriteCloser.  This is useful for masking implementations for interfaces
+// like ReaderFrom which may be opted into use inside functions like io.Copy.
+type writeCloserNoCopy struct {
+	io.WriteCloser
+}
+
+// nopWriteCloser is an io.WriteCloser that has a noop Close method.  This type
+// has the effect of masking the underlying writer's Close implementation if it
+// has one, or satisfying interface implementations for writers that do not
+// need to be closing.
+type nopWriteCloser struct {
+	io.Writer
+}
+
+func (w *nopWriteCloser) Close() error {
+	return nil
 }


### PR DESCRIPTION
I cleaned up the benchmarks and added versions that avoid use of the io.Copy interfaces by masking the methods on `*reader` and `*BufferedWriter`.

Aside from the direct goal of adding benchmarks without the io.Copy interfaces and cleaning up the mess I made earlier, I want this to be flexible enough to fit potential future enhancements which provide optional or "sliding scale" optimizations significant enough to warrant distinction. I think the `enc` and `dec` function arguments to `benchmarkEncode` and `benchmarkDecode` respectively should be sufficient for future tasks.

Furthermore, now it's straight forward to add more raw test data to `fixturedata_test.go`. Although I think a future enhancement would be to move the raw data to individual files in a subdirectory. But I digress...
