### PR TITLE
fix error handling bugs in reader.WriteTo

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -74,7 +74,10 @@ func (r *reader) WriteTo(w io.Writer) (int64, error) {
 
 	// pass a bufferFallbackWriter to nextFrame so that write errors may be
 	// recovered from, allowing the unwritten stream to be read successfully.
-	wfallback := r.bufferFallbackWriter(w)
+	wfallback := &bufferFallbackWriter{
+		w:   w,
+		buf: &r.buf,
+	}
 	for {
 		var m int
 		m, err = r.nextFrame(wfallback)
@@ -95,13 +98,6 @@ func (r *reader) WriteTo(w io.Writer) (int64, error) {
 		}
 	}
 	panic("unreachable")
-}
-
-func (r *reader) bufferFallbackWriter(w io.Writer) *bufferFallbackWriter {
-	return &bufferFallbackWriter{
-		w:   w,
-		buf: &r.buf,
-	}
 }
 
 // bufferFallbackWriter writes to an underlying io.Writer until an error


### PR DESCRIPTION
I noticed a couple bugs in how I implemented reader.WriteTo. Here's a summary of the changes.
- r.err is checked before r.WriteTo begins writing. This avoids potentially writing
  corrupt data to the io.Writer after a previous decoding error.
- r.err is set when decoding errors occur in r.WriteTo. A copyWriter
  type is introduced to let r.WriteTo distinguish decoding errors vs
  write errors and allow reading to safely resume after a write error
  occurs.
